### PR TITLE
Attaches quoting tweets to the tweet they quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # CFViewer
+
+CFViewer is a tool that gives an interface to view a long twitter conversation in
+a compact tree view. Twitter web conversation view is only helpful for linear 
+conversations. But the most intersting conversations have branches and
+sometimes the most important tidbits are hidden in those branches.
+
+CFViewer aims to help you follow a long branched conversation in a slightly
+more convenient manner.
+
+The project was born on an interesting Sunday evening.
+
+CFViewer is built by [@thameera](https://twitter.com/thameera) with some contributions 
+from [@chanux](https://twitter.com/chanux)
+
+Now enjoy [CFV](http://cfv.bestatlk.com)

--- a/index.js
+++ b/index.js
@@ -43,10 +43,6 @@ app.post('/api/get-tweets', (req, res) => {
     });
 });
 
-app.get('/', (req, res) => {
-  res.sendfile('public/index.html');
-});
-
 app.listen(process.env.APP_PORT, () => {
-  console.log('Listening on port 8081!');
+  console.log('Listening on port ' + process.env.APP_PORT + '!');
 });

--- a/twitter.js
+++ b/twitter.js
@@ -92,7 +92,7 @@ const buildTree = (start_id, tweets) => {
   const iterateForQuotingTweets = (id) => {
     findQuoted(id).forEach(t => {
       add(t, id);
-      iterateForReplies(id);
+      iterateForReplies(t.id_str);
     });
   };
 

--- a/twitter.js
+++ b/twitter.js
@@ -88,6 +88,14 @@ const buildTree = (start_id, tweets) => {
   // Find all tweets which quote given tweet id
   const findQuoted = id => _.filter(tweets, { quoted_status_id_str: id});
 
+  // Find tweets that quote current tweet and add to the tree
+  const iterateForQuotingTweets = (id) => {
+    findQuoted(id).forEach(t => {
+      add(t, id);
+      iterateForReplies(id);
+    });
+  };
+
   const iterateForReplies = id => {
     // Get all replies to the tweet with given ID
     const replies = _.remove(tweets, { in_reply_to_status_id_str: id });
@@ -97,11 +105,7 @@ const buildTree = (start_id, tweets) => {
     replies.forEach(r => {
       add(r, id);
       iterateForReplies(r.id_str);
-      // Find tweets that quote current tweet and add to the tree
-      findQuoted(r.id_str).forEach(t => {
-        add(t, r.id_str);
-        iterateForReplies(t.id_str);
-      });
+      iterateForQuotingTweets(r.id_str);
     });
   };
 
@@ -115,6 +119,7 @@ const buildTree = (start_id, tweets) => {
     add(root, '#');
 
     iterateForReplies(root.id_str);
+    iterateForQuotingTweets(root.id_str);
   };
 
   iterateRoot(start_id);

--- a/twitter.js
+++ b/twitter.js
@@ -85,17 +85,20 @@ const buildTree = (start_id, tweets) => {
     });
   };
 
-  const findQuoted = id => _.filter(tweets, { quoted_status_id_str: id }).map(t => t.id_str);
+  // Find all tweets which quote given tweet id
+  const findQuoted = id => _.filter(tweets, { quoted_status_id_str: id});
 
-  const iterateForTweet = id => {
+  const iterateForReplies = id => {
+    // Get all replies to the tweet with given ID
     const replies = _.remove(tweets, { in_reply_to_status_id_str: id });
 
     if (!replies || !replies.length) return;
 
     replies.forEach(r => {
       add(r, id);
-      iterateForTweet(r.id_str);
-      findQuoted(r.id_str).forEach(id => iterateRoot(id));
+      iterateForReplies(r.id_str);
+      // Find tweets that quote current tweet and add to the tree
+      findQuoted(r.id_str).forEach(t => add(t, r.id_str));
     });
   };
 
@@ -103,13 +106,12 @@ const buildTree = (start_id, tweets) => {
     console.log(`Iterating for root tweet: ${root_id}`);
     // Find root tweet
     const root = _.find(tweets, { id_str: root_id });
-    if (!root) return 'Root tweet not found';
 
-    findQuoted(root_id).forEach(id => iterateRoot(id));
+    if (!root) return 'Root tweet not found';
 
     add(root, '#');
 
-    iterateForTweet(root.id_str);
+    iterateForReplies(root.id_str);
   };
 
   iterateRoot(start_id);

--- a/twitter.js
+++ b/twitter.js
@@ -98,7 +98,10 @@ const buildTree = (start_id, tweets) => {
       add(r, id);
       iterateForReplies(r.id_str);
       // Find tweets that quote current tweet and add to the tree
-      findQuoted(r.id_str).forEach(t => add(t, r.id_str));
+      findQuoted(r.id_str).forEach(t => {
+        add(t, r.id_str);
+        iterateForReplies(t.id_str);
+      });
     });
   };
 


### PR DESCRIPTION
Adds a README

Currently tweets that quote a tweet already in a tree is added to the root node. But it seems more appropriate that such tweets be childs of the tweet they quote. Because a quoting tweet is essentially commenting about quoted tweet (or people abuse it using as a reply).
